### PR TITLE
投稿機能で投稿者とログインユーザを区別できるように修正

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,11 +1,12 @@
 class PostsController < ApplicationController
   def index
-    @posts = Post.where(user_id: current_user.id).order(day: "DESC")
+    @posts = Post.where(user_id: params[:format]).order(day: "DESC")
+    @user = User.find(params[:format])
   end
 
   def show
     @post = Post.find(params[:id])
-    @todos = Todo.where(user_id: current_user.id).where(day: @post.day)
+    @todos = Todo.where(user_id: @post.user_id).where(day: @post.day)
   end
 
   def new
@@ -17,7 +18,7 @@ class PostsController < ApplicationController
     post.user_id = current_user.id
 
     if post.save
-      redirect_to post_path(post)
+      redirect_to post_path(post.id)
     else
       render :new
     end

--- a/app/views/layouts/_footer.html.slim
+++ b/app/views/layouts/_footer.html.slim
@@ -1,5 +1,3 @@
-footer.page-footer.font-small
+footer.page-footer
   .footer-copyright.text-center.py-3
-    | © 2019 Copyright:
-    a[href=""]
-      |  calcal
+    | © 2019 Copyright: calcal

--- a/app/views/layouts/_header.html.slim
+++ b/app/views/layouts/_header.html.slim
@@ -8,7 +8,7 @@ nav.navbar.navbar-light.navbar-expand-md.nav-color
 
       ul.navbar-nav.ml-auto
         li.nav-item
-          = link_to "検索", posts_search_list_path, class: "fa fa-search mr-2"
+          = link_to "投稿検索", posts_search_list_path, class: "fa fa-search mr-2"
 
         /サイドメニューの表示
         button.nav-item.drawer-toggle.drawer-hamburger[type="button"]

--- a/app/views/layouts/_usermenu.html.slim
+++ b/app/views/layouts/_usermenu.html.slim
@@ -20,10 +20,6 @@ nav.drawer-nav
 
     li.drawer-menu-item
       a[href="#"]
-        | いいね一覧
-
-    li.drawer-menu-item
-      a[href="#"]
         = link_to "投稿一覧", posts_path(current_user)
 
     li.drawer-menu-item

--- a/app/views/posts/_post_list.html.slim
+++ b/app/views/posts/_post_list.html.slim
@@ -1,12 +1,18 @@
 table.table.mt-3
   thead.thead-light
     tr
+      th ユーザ
       th 日付
       th タイトル
       th コメント
   tbody
     - posts.each do |post|
       tr.post_row data-href="/posts/#{post.id}"
+        td
+          - if post.user.image.blank?
+            = image_tag "/assets/noimage.jpg", :size => '100x100', class: 'img-thumbnail rounded'
+          - else
+            = image_tag post.user.image.to_s, :size => '100x100', class: 'img-thunmbnail rounded'
         td
           = post.day
         td

--- a/app/views/posts/edit.html.slim
+++ b/app/views/posts/edit.html.slim
@@ -15,9 +15,9 @@
         = form.label :content, 'コメント'
         = form.text_area :content, class: 'form-control', rows:2
 
-      = form.submit '編集する', class: 'post_submit btn btn-primary mr-4 mb-4'
-
-    = link_to "キャンセル", posts_path, class: 'btn btn-warning'
+      .btn-group
+        = form.submit '編集する', class: 'post_submit btn btn-primary mr-4'
+        = link_to "キャンセル", posts_path(current_user.id), class: 'btn btn-warning'
 
   .col-sm-6
     table#todo_lists.table

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -5,26 +5,30 @@
         .col-sm-6
           /プロフィール画像
           .post_profile_content
-            - if current_user.image.blank?
+            - if @user.image.blank?
               = image_tag "/assets/noimage.jpg", :size => '150x150', class: 'img-thumbnail rounded'
             - else
-              = image_tag current_user.image.to_s, :size => '150x150', class: 'img-thumbnail rounded'
+              = image_tag @user.image.to_s, :size => '150x150', class: 'img-thumbnail rounded'
 
           /ユーザー名
           h5.post_profile_content.text-center.mt-2
-            -if current_user.name.blank?
+            -if @user.name.blank?
               | no name
             -else
-              = current_user.name
+              = @user.name
 
         /プロフィール文
         .col-sm-6
           .post_profile_content
-            | content
+            -if @user.profile.blank?
+              | no_message
+            -else
+              = @user.profile
 
-    .col-sm-8.to_new_post.align-self-center
-      .row.justify-content-center
-        = link_to "投稿ページへ", new_post_path(current_user.id), class: 'btn btn-primary'
+    - if @user == current_user
+      .col-sm-8.to_new_post.align-self-center
+        .row.justify-content-center
+          = link_to "投稿ページへ", new_post_path(current_user.id), class: 'btn btn-primary'
 
 .container
   .post_todo_list

--- a/app/views/posts/new.html.slim
+++ b/app/views/posts/new.html.slim
@@ -15,9 +15,9 @@
         = form.label :content, 'コメント'
         = form.text_area :content, class: 'form-control', rows:2
 
-      = form.submit '投稿する', class: 'post_submit btn btn-primary mr-4 mb-4'
-
-    = link_to "キャンセル", posts_path, class: 'btn btn-warning'
+      .btn-group
+      = form.submit '投稿する', class: 'post_submit btn btn-primary mr-4'
+      = link_to "キャンセル", posts_path(current_user.id), class: 'btn btn-warning'
 
   .col-sm-6
     table#todo_lists.table

--- a/app/views/posts/search_list.html.slim
+++ b/app/views/posts/search_list.html.slim
@@ -21,6 +21,7 @@
       table.table.mt-3
         thead.thead-light
           tr
+            th ユーザ
             th 日付
             th タイトル
             th コメント

--- a/app/views/posts/show.html.slim
+++ b/app/views/posts/show.html.slim
@@ -13,12 +13,16 @@
       label コメント
       p.post_content.bg-white.border = @post.content
 
-    .btn-group.mt-3
-      = link_to "編集する", edit_post_path(@post), class: 'btn btn-primary'
-
-      = link_to "一覧に戻る", posts_path, class: 'btn btn-warning mr-2 ml-2'
-
-      = link_to "削除する", post_path(@post), class: 'btn btn-danger', method: :delete, remote: true
+    - if @post.user_id == current_user.id
+      .btn-group.mt-3
+        = link_to "編集する", edit_post_path(@post), class: 'btn btn-primary'
+        = link_to "一覧に戻る", posts_path(current_user.id), class: 'btn btn-warning mr-2 ml-2'
+        = link_to "削除する", post_path(@post), class: 'btn btn-danger', method: :delete, remote: true
+    - else
+      .btn-group.mt-3
+        = link_to "検索画面へ", posts_search_list_path, class: 'btn btn-primary'
+        = link_to "このユーザの投稿一覧へ", posts_path(@post.user_id), class: 'btn btn-warning mr-2 ml-2'
+        = link_to "カレンダーへ", calender_path(current_user.id), class: 'btn btn-info'
 
   .col-sm-6
     = render partial: "posts/todo_list", locals: { todos: @todos, post: @post }


### PR DESCRIPTION
-  current_userを使用していたので、
他のユーザの投稿（post）ページへの移動や表示が、
ログインユーザになってしまったので、
ログインユーザと投稿者が区別できるように修正

-  ヘッダー,フッター,ユーザメニュー,ボタンの配置を修正