### PR TITLE
noimage.jpgのパス変更

### DIFF
--- a/app/views/layouts/_usermenu.html.slim
+++ b/app/views/layouts/_usermenu.html.slim
@@ -4,7 +4,7 @@ nav.drawer-nav
     /プロフィール画像
     .text-center.mt-3.mb-3
       - if current_user.image.blank?
-        = image_tag "/assets/noimage.jpg", :size => '100x100', class: 'img-thumbnail rounded'
+        = image_tag "noimage.jpg", :size => '100x100', class: 'img-thumbnail rounded'
       - else
         = image_tag current_user.image.to_s, :size => '100x100', class: 'img-thunbnail rounded'
 

--- a/app/views/posts/_post_list.html.slim
+++ b/app/views/posts/_post_list.html.slim
@@ -10,7 +10,7 @@ table.table.mt-3
       tr.post_row data-href="/posts/#{post.id}"
         td
           - if post.user.image.blank?
-            = image_tag "/assets/noimage.jpg", :size => '100x100', class: 'img-thumbnail rounded'
+            = image_tag "noimage.jpg", :size => '100x100', class: 'img-thumbnail rounded'
           - else
             = image_tag post.user.image.to_s, :size => '100x100', class: 'img-thunmbnail rounded'
         td

--- a/app/views/posts/index.html.slim
+++ b/app/views/posts/index.html.slim
@@ -6,7 +6,7 @@
           /プロフィール画像
           .post_profile_content
             - if @user.image.blank?
-              = image_tag "/assets/noimage.jpg", :size => '150x150', class: 'img-thumbnail rounded'
+              = image_tag "noimage.jpg", :size => '150x150', class: 'img-thumbnail rounded'
             - else
               = image_tag @user.image.to_s, :size => '150x150', class: 'img-thumbnail rounded'
 

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -12,7 +12,7 @@
             = image_tag @user.image.to_s, :size => '300x200', class: 'mg-thumbnail rounded d-block mt-3'
 
           - else
-            = image_tag "/assets/noimage.jpg", :size => '300x200', class: 'mg-thumbnail rounded d-block mt-3'
+            = image_tag "noimage.jpg", :size => '300x200', class: 'mg-thumbnail rounded d-block mt-3'
 
       = form_with(model: @user, local: true, class: "validate_field") do |form|
         .form-group


### PR DESCRIPTION
assets配下のimageを表示させる場合、
productionではファイルパスを書くと画像が表示されないので、
ファイルパスを削除しました。