### PR TITLE
drawer.jsの修正

### DIFF
--- a/app/assets/javascripts/usermenu.js
+++ b/app/assets/javascripts/usermenu.js
@@ -1,3 +1,9 @@
-document.addEventListener('turbolinks:load', function() {
-      $('.drawer').drawer();
+// ヘッダーのプロフィールをクリックするとメニューが表示される
+$(document).ready(function(){
+  document.addEventListener('turbolinks:load', function() {
+    $('.drawer').drawer();
+    $('.drawer-nav').on('click', function() {
+      $('.drawer').drawer('close');
+    });
+  });
 });


### PR DESCRIPTION
drawer.jsで表示させたメニューからリンクをクリックしたあと、
リンク先から「戻る」とメニューが開いたままになる不具合が発生。
リンクをクリックした後にメニューを閉じる処理を発火させることで解消。